### PR TITLE
Introduce synergy between frontend and gateway

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
                  [org.clojure/core.async "0.2.371"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.taoensso/timbre "4.7.4"]
+                 [com.cognitect/transit-clj "0.8.290"]
                  [clj-time "0.11.0"]
-                 [cheshire "5.5.0"]
                  [http-kit "2.1.19"]
                  [ring-cors "0.1.8"]
                  [compojure "1.5.1"]
@@ -14,7 +14,7 @@
                  [aero "1.0.0-beta5"]
                  [clj-time "0.12.0"]
                  [org.clojure/data.codec "0.1.0"]
-                 [kixi/kixi.comms "0.1.11" :exclusions [cheshire]]]
+                 [kixi/kixi.comms "0.1.12"]]
   :source-paths ["src"]
   :profiles {:uberjar {:aot  :all
                        :main witan.gateway.system

--- a/test/witan/gateway/handler_test.clj
+++ b/test/witan/gateway/handler_test.clj
@@ -1,0 +1,13 @@
+(ns witan.gateway.handler-test
+  (:require [witan.gateway.handler :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest conform-add-created-at-test
+  (let [command {:kixi.comms.message/type "command"
+                 :kixi.comms.command/key :foo/bar
+                 :kixi.comms.command/version "1.0.0"
+                 :kixi.comms.command/id (str (java.util.UUID/randomUUID))
+                 :kixi.comms.command/payload {}}
+        [_ r] (conform command)]
+    (is (not (= :clojure.spec/invalid r)))
+    (is (contains? r :kixi.comms.command/created-at) (pr-str r))))

--- a/test/witan/gateway/integration/base.clj
+++ b/test/witan/gateway/integration/base.clj
@@ -1,6 +1,8 @@
 (ns witan.gateway.integration.base
   (:require [user :as repl]
             [environ.core :refer [env]]
+            [gniazdo.core :as ws]
+            [witan.gateway.handler :refer [transit-encode transit-decode]]
             [taoensso.timbre :as log]))
 
 (defn uuid [] (str (java.util.UUID/randomUUID)))
@@ -11,6 +13,15 @@
   (Thread/sleep 2000)
   (all-tests)
   (repl/stop)
+  (reset! a nil))
+
+(defn create-ws-connection
+  [a received-fn all-tests]
+  (reset! a (ws/connect "ws://localhost:30015/ws"
+                        :on-receive #(if @received-fn
+                                       (@received-fn (transit-decode %)))))
+  (all-tests)
+  (ws/close @a)
   (reset! a nil))
 
 (defn wait-for-pred


### PR DESCRIPTION
Now both use transit-clj(s) and `:json-verbose` - should now be easy to crank up/down verbosity in future
