### PR TITLE
Allows ZK_PATH to be specified by envar

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,6 +1,6 @@
 {:comms {:kafka {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]
                                  :production "master.mesos"}
-                 :zk-path #profile {:development "/"
+                 :zk-path #profile {:development #or [#env ZK_PATH "/"]
                                     :production "/dcos-service-kafka/"}
                  :port 2181}}
  :connections {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]


### PR DESCRIPTION
This is so it can be overridden by jenkins