### PR TITLE
Allow downloads made via /download

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,7 @@
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.9.0-alpha13"]
                  [org.clojure/core.async "0.2.371"]
+                 [org.clojure/data.codec "0.1.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.taoensso/timbre "4.7.4"]
                  [com.cognitect/transit-clj "0.8.290"]
@@ -9,6 +10,7 @@
                  [clj-time "0.11.0"]
                  [http-kit "2.1.19"]
                  [ring-cors "0.1.8"]
+                 [ring/ring-core "1.5.1"]
                  [compojure "1.5.1"]
                  [clj-http "2.1.0"]
                  [environ "1.1.0"]
@@ -23,5 +25,6 @@
                        :uberjar-name "witan.gateway-standalone.jar"}
              :dev {:source-paths ["dev-src"]
                    :dependencies [[org.clojure/tools.namespace "0.2.4"]
-                                  [stylefruits/gniazdo "1.0.0"]]
+                                  [stylefruits/gniazdo "1.0.0"]
+                                  [me.raynes/fs "1.4.6"]]
                    :repl-options {:init-ns user}}})

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -25,4 +25,5 @@
                                   :production {:host "kixi.datastore.marathon.mesos"
                                                :port 18080}}}
  :log {:level #profile {:development :info
-                        :production  :info}}}
+                        :production  :info}}
+ :downloads {:timeout 10000}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -3,9 +3,10 @@
                  :zk-path #profile {:development #or [#env ZK_PATH "/"]
                                     :production "/dcos-service-kafka/"}
                  :port 2181}}
- :connections {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]
-                               :production "master.mesos"}
-               :port 2181}
+ :events {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]
+                          :production "master.mesos"}
+          :port 2181}
+ :connections {}
  :webserver {:port 30015}
  :auth {:pubkey #profile {:development #or [#env SUPER_SECRET_PUBLIC_PEM_FILE
                                             "./test-resources/heimdall-dev_pubkey.pem"]

--- a/src/witan/gateway/components/connection_manager.clj
+++ b/src/witan/gateway/components/connection_manager.clj
@@ -13,7 +13,7 @@
 (defrecord ConnectionManager [host port]
   ManageConnections
   (process-event! [{:keys [receipts]} event]
-    (log/info "Observed event" (:kixi.comms.event/id event))
+    (log/info "Observed event" (:kixi.comms.event/id event) (:kixi.comms.event/key event))
     (when-let [id (:kixi.comms.command/id event)]
       (try
         (when-let [{:keys [cb]} (get @receipts id)]

--- a/src/witan/gateway/components/downloads.clj
+++ b/src/witan/gateway/components/downloads.clj
@@ -13,10 +13,11 @@
         pd (:pending-downloads this)
         user-id (get-in payload [:kixi/user :kixi.user/id])
         ch (get-in @pd [user-id id])]
-    (when link
-      (put! ch link))
-    (close! ch)
-    (swap! pd update user-id #(dissoc % id))
+    (when ch
+      (when link
+        (put! ch link))
+      (close! ch)
+      (swap! pd update user-id #(dissoc % id)))
     nil))
 
 (defrecord DownloadManager [timeout]

--- a/src/witan/gateway/components/downloads.clj
+++ b/src/witan/gateway/components/downloads.clj
@@ -8,14 +8,14 @@
 (defn handle-download-event-fn [ch]
   (fn [event]
     (when (or (= :kixi.datastore.filestore/download-link-created (:kixi.comms.event/key event))
-              (= :kixi.datastore.filestore/download-link-rejected (:kixi.comms.event/key event))))
-    (let [{:keys [kixi.comms.event/payload]} event
-          {:keys [kixi.datastore.metadatastore/link
-                  kixi.datastore.metadatastore/id]} payload]
-      (when link
-        (put! ch link))
-      (close! ch)
-      nil)))
+              (= :kixi.datastore.filestore/download-link-rejected (:kixi.comms.event/key event)))
+      (let [{:keys [kixi.comms.event/payload]} event
+            {:keys [kixi.datastore.metadatastore/link
+                    kixi.datastore.metadatastore/id]} payload]
+        (when link
+          (put! ch link))
+        (close! ch)
+        nil))))
 
 (defrecord DownloadManager [timeout]
   ManageDownloads

--- a/src/witan/gateway/components/downloads.clj
+++ b/src/witan/gateway/components/downloads.clj
@@ -1,0 +1,57 @@
+(ns witan.gateway.components.downloads
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre            :as log]
+            [clojure.core.async :as async :refer [chan go go-loop put! <! <!! close!]]
+            [witan.gateway.protocols    :as p :refer [ManageDownloads]]
+            [kixi.comms :as c]))
+
+(defn on-download-link
+  [this args]
+  (let [{:keys [kixi.comms.event/payload]} args
+        {:keys [kixi.datastore.metadatastore/link
+                kixi.datastore.metadatastore/id]} payload
+        pd (:pending-downloads this)
+        user-id (get-in payload [:kixi/user :kixi.user/id])
+        ch (get-in @pd [user-id id])]
+    (when link
+      (put! ch link))
+    (close! ch)
+    (swap! pd update user-id #(dissoc % id))
+    nil))
+
+(defrecord DownloadManager [timeout]
+  ManageDownloads
+  (create-download-redirect [{:keys [pending-downloads comms]} user file-id]
+    (log/info "Attempting to redirect download for user"
+              (:kixi.user/id user) "to file" file-id)
+    (let [download-chan (chan 1)]
+      (swap! pending-downloads update (:kixi.user/id user) #(assoc % file-id download-chan))
+      (c/send-command! comms :kixi.datastore.filestore/create-download-link "1.0.0"
+                       user
+                       {:kixi.datastore.metadatastore/id file-id})
+      (let [[v p] (async/alts!! [download-chan (async/timeout (or timeout 10000))])]
+        (when (= p download-chan)
+          v))))
+
+  component/Lifecycle
+  (start [{:keys [comms] :as component}]
+    (log/info "Starting Download Manager")
+    (let [cp (assoc component :pending-downloads (atom {}))
+          event-handlers [(c/attach-event-handler! comms :download-manager-link-success
+                                                   :kixi.datastore.filestore/download-link-created "1.0.0"
+                                                   (partial on-download-link cp))
+                          (c/attach-event-handler! comms :download-manager-link-failure
+                                                   :kixi.datastore.filestore/download-link-rejected "1.0.0"
+                                                   (partial on-download-link cp))]]
+      (assoc cp :event-handlers event-handlers)))
+
+  (stop [{:keys [comms] :as component}]
+    (log/info "Stopping Download Manager")
+    (run! (partial c/detach-handler! comms) (:event-handlers component))
+    (-> component
+        (dissoc :pending-downloads) ;; Do we need to close any open chans?
+        (dissoc :event-handlers))))
+
+(defn new-download-manager
+  [config]
+  (->DownloadManager (:timeout config)))

--- a/src/witan/gateway/components/events.clj
+++ b/src/witan/gateway/components/events.clj
@@ -11,7 +11,7 @@
   [receivers event]
   (log/info "Observed event" (:kixi.comms.event/id event) (:kixi.comms.event/key event))
   (when (and receivers (not-empty @receivers))
-    (log/info "Forwarding to" (count @receivers) "receiver(s)...")
+    (log/debug "Forwarding to" (count @receivers) "receiver(s)...")
     (run! (fn [x] (x event)) @receivers))
   nil)
 

--- a/src/witan/gateway/components/events.clj
+++ b/src/witan/gateway/components/events.clj
@@ -1,0 +1,48 @@
+(ns witan.gateway.components.events
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre            :as log]
+            [clj-time.core              :as t]
+            [clojure.spec               :as s]
+            [kixi.comms                 :as c]
+            [witan.gateway.protocols    :as p :refer [AggregateEvents]]
+            [zookeeper                  :as zk]))
+
+(defn handle-events
+  [receivers event]
+  (log/info "Observed event" (:kixi.comms.event/id event) (:kixi.comms.event/key event))
+  (when (and receivers (not-empty @receivers))
+    (log/info "Forwarding to" (count @receivers) "receiver(s)...")
+    (run! (fn [x] (x event)) @receivers))
+  nil)
+
+(defrecord EventAggregator [host port]
+  AggregateEvents
+  (register-event-receiver! [{:keys [receivers]} handler-fn]
+    (swap! receivers conj handler-fn))
+  (unregister-event-receiver! [{:keys [receivers]} handler-fn]
+    (swap! receivers disj handler-fn))
+  component/Lifecycle
+  (start [{:keys [comms] :as component}]
+    (log/info "Starting Event Aggregator")
+    (let [zk (zk/connect (str host ":" port))
+          seq-name (zk/create-all zk "/kixi/gateway/events/consumer-" :sequential? true)
+          consumer-name (clojure.string/replace seq-name #"/" "-")
+          receivers (atom #{})
+          eh (c/attach-event-with-key-handler!
+              (assoc-in comms [:consumer-config :auto.offset.reset] :latest)
+              consumer-name
+              :kixi.comms.command/id
+              (partial handle-events receivers))]
+      (zk/close zk)
+      (assoc component
+             :event-handler eh
+             :receivers receivers)))
+
+  (stop [component]
+    (log/info "Stopping Event Aggregator")
+    (dissoc component
+            :event-handler
+            :receivers)))
+
+(defn new-event-aggregator [args]
+  (map->EventAggregator args))

--- a/src/witan/gateway/components/server.clj
+++ b/src/witan/gateway/components/server.clj
@@ -1,7 +1,8 @@
 (ns witan.gateway.components.server
   (:gen-class)
   (:require [org.httpkit.server           :as httpkit]
-            [ring.middleware.content-type :refer [wrap-content-type]]
+            [ring.middleware.cookies      :refer [wrap-cookies]]
+            [ring.middleware.params       :refer [wrap-params]]
             [com.stuartsierra.component   :as component]
             [witan.gateway.handler        :refer [app]]
             [taoensso.timbre              :as log]
@@ -36,10 +37,11 @@
     (assoc this :http-kit (httpkit/run-server
                            (-> #'app
                                (wrap-catch-exceptions)
+                               (wrap-cookies)
+                               (wrap-params)
                                (wrap-directory directory)
                                (wrap-components this)
                                (wrap-log)
-                               (wrap-content-type "application/json")
                                (wrap-cors :access-control-allow-origin [#".*"]
                                           :access-control-allow-methods [:get :post]))
                            {:port port})))

--- a/src/witan/gateway/protocols.clj
+++ b/src/witan/gateway/protocols.clj
@@ -32,3 +32,9 @@
 
 (defprotocol ManageDownloads
   (create-download-redirect [this user file-id]))
+
+;;;;;;;;;
+
+(defprotocol AggregateEvents
+  (register-event-receiver! [this handler-fn])
+  (unregister-event-receiver! [this handler-fn]))

--- a/src/witan/gateway/protocols.clj
+++ b/src/witan/gateway/protocols.clj
@@ -27,3 +27,8 @@
 
 (defprotocol Authenticate
   (authenticate [this time auth-token]))
+
+;;;;;;;;;
+
+(defprotocol ManageDownloads
+  (create-download-redirect [this user file-id]))

--- a/test/witan/gateway/integration/downloads_test.clj
+++ b/test/witan/gateway/integration/downloads_test.clj
@@ -1,0 +1,136 @@
+(ns witan.gateway.integration.downloads-test
+  (:require [clojure.test :refer :all]
+            [witan.gateway.protocols :as p]
+            [witan.gateway.integration.base :refer :all]
+            [witan.gateway.handler :refer [transit-encode transit-decode]]
+            [kixi.comms :as c]
+            [kixi.comms.time :refer [timestamp]]
+            [buddy.core.keys            :as keys]
+            [buddy.sign.jwt             :as jwt]
+            [taoensso.timbre :as log]
+            [clj-http.client :as http]
+            [clj-time.core :as t]
+            [me.raynes.fs :as fs]
+            [clojure.java.shell :refer [sh]]))
+
+(def system (atom nil))
+(def file-id (atom nil))
+(def auth-token (atom nil))
+(def test-file-contents (str "hello, world " (uuid)))
+
+(defn test-login
+  [auth]
+  (let [tkp (-> "http://localhost:30015/login"
+                (http/post
+                 {:body "{\"username\": \"test@mastodonc.com\", \"password\": \"Secret123\"}"})
+                :body
+                (transit-decode))]
+    (reset! auth-token (get-in tkp [:token-pair :auth-token]))
+    (p/authenticate auth (t/now) (get-in tkp [:token-pair :auth-token]))))
+
+(defn find-datastore-docker-id
+  []
+  (let [ds-line (first
+                 (filter (partial re-find #"datastore")
+                         (rest (clojure.string/split (:out (sh "docker" "ps"))
+                                                     (re-pattern (str \newline))))))]
+    (re-find #"[a-zA-Z0-9]+" ds-line)))
+
+(defn cp-to-docker
+  [tmpfile upload-link]
+  (let [sh-line ["docker" "cp" (str tmpfile) (str (find-datastore-docker-id) ":" upload-link)]]
+    (println (apply sh sh-line))))
+
+(defn slurp-from-docker
+  [file]
+  (let [tmpfile (fs/temp-file "gateway-download-slurp-test-")
+        sh-line ["docker" "cp" (str (find-datastore-docker-id) ":" file) (str tmpfile)]]
+    (println (apply sh sh-line) sh-line)
+    (slurp tmpfile)))
+
+(defn put-to-aws
+  [tmpfile upload-link]
+  (http/put upload-link {:body tmpfile}))
+
+(defn upload-file-to-correct-location
+  [comms user file-contents {:keys [kixi.comms.event/payload]}]
+  (let [{:keys [kixi.datastore.filestore/upload-link
+                kixi.datastore.filestore/id]} payload
+        metadata {:kixi.datastore.metadatastore/name "Test File"
+                  :kixi.datastore.metadatastore/description "Test Description"
+                  :kixi.datastore.metadatastore/id id
+                  :kixi.datastore.metadatastore/type "stored"
+                  :kixi.datastore.metadatastore/file-type "txt"
+                  :kixi.datastore.metadatastore/sharing
+                  {:kixi.datastore.metadatastore/meta-read (:kixi.user/groups user)
+                   :kixi.datastore.metadatastore/meta-update (:kixi.user/groups user)
+                   :kixi.datastore.metadatastore/file-read (:kixi.user/groups user)}
+                  :kixi.datastore.metadatastore/provenance
+                  {:kixi.datastore.metadatastore/source "upload"
+                   :kixi.user/id (:kixi.user/id user)}
+                  :kixi.datastore.metadatastore/size-bytes (count file-contents)
+                  :kixi.datastore.metadatastore/header false}
+        tmpfile (fs/temp-file (str "gateway-download-test-" id "_"))]
+    (spit tmpfile file-contents)
+    (log/info "Uploading test file to" upload-link)
+    (if (clojure.string/starts-with? upload-link "file:")
+      (cp-to-docker tmpfile (subs upload-link 7))
+      (put-to-aws tmpfile upload-link))
+    (Thread/sleep 300)
+    (c/send-command! comms :kixi.datastore.filestore/create-file-metadata "1.0.0" user metadata)
+    nil))
+
+(defn upload-file
+  [system file-id-atom all-tests]
+  (let [{:keys [comms auth]} @system
+        user (test-login auth)
+        ehs [(c/attach-event-handler!
+              comms
+              :download-test-upload-link-created
+              :kixi.datastore.filestore/upload-link-created "1.0.0"
+              (partial upload-file-to-correct-location comms user test-file-contents))
+             (c/attach-event-handler!
+              comms
+              :download-test-file-metadata-rejected
+              :kixi.datastore.file-metadata/rejected "1.0.0"
+              (fn [payload]
+                (log/error "Download test file was rejected:" payload) nil))
+             (c/attach-event-handler!
+              comms
+              :download-test-file-metadata-created
+              :kixi.datastore.file/created "1.0.0"
+              (fn [{:keys [kixi.comms.event/payload]}]
+                (let [{:keys [kixi.datastore.metadatastore/id]} payload]
+                  (reset! file-id-atom id))
+                nil))]]
+    (c/send-command! comms :kixi.datastore.filestore/create-upload-link "1.0.0" user nil)
+    (wait-for-pred #(deref file-id-atom))
+    (run! (partial c/detach-handler! comms) ehs)
+    (if-not (clojure.string/blank? @file-id-atom)
+      (all-tests)
+      (throw (Exception. "Tests could not be run")))))
+
+(use-fixtures :once
+  (partial cycle-system-fixture system)
+  (partial upload-file system file-id))
+
+(deftest download-without-token-or-query
+  (let [r (http/get "http://localhost:30015/download"
+                    {:throw-exceptions false})]
+    (is (= 401 (:status r)))))
+
+(deftest download-without-token
+  (let [r (http/get (str "http://localhost:30015/download?id=" @file-id)
+                    {:throw-exceptions false})]
+    (is (= 401 (:status r)))))
+
+(deftest download
+  (let [r (http/get (str "http://localhost:30015/download?id=" @file-id)
+                    {:throw-exceptions false
+                     :cookies {"token" {:discard true, :path "/", :value @auth-token, :version 0}}
+                     :follow-redirects false})]
+    (is (= 302 (:status r)))
+    (when-let [redirect (get-in r [:headers "Location"])]
+      (if (clojure.string/starts-with? redirect "file:")
+        (is (= test-file-contents (slurp-from-docker (subs redirect 7))))
+        (is (= test-file-contents (slurp redirect)))))))


### PR DESCRIPTION
The gateway now internally handles creating download links and forwarding them as the response of an HTTP GET to /download