### PR TITLE
Fixes the download test by culling events by command ID

### DIFF
--- a/test/witan/gateway/integration/base.clj
+++ b/test/witan/gateway/integration/base.clj
@@ -27,9 +27,11 @@
   [a all-tests]
   (reset! a (repl/go))
   (Thread/sleep 2000)
-  (all-tests)
-  (repl/stop)
-  (reset! a nil))
+  (try
+    (all-tests)
+    (finally
+      (repl/stop)
+      (reset! a nil))))
 
 (defn create-ws-connection
   [a received-fn all-tests]

--- a/test/witan/gateway/integration/downloads_test.clj
+++ b/test/witan/gateway/integration/downloads_test.clj
@@ -84,6 +84,7 @@
   [system file-id-atom all-tests]
   (let [{:keys [comms auth]} @system
         user (test-login auth)
+        _ (log/info "Result of test login:" user)
         ehs [(c/attach-event-handler!
               comms
               :download-test-upload-link-created
@@ -103,7 +104,9 @@
                 (let [{:keys [kixi.datastore.metadatastore/id]} payload]
                   (reset! file-id-atom id))
                 nil))]]
+    _ (log/info "Handlers attached." )
     (c/send-command! comms :kixi.datastore.filestore/create-upload-link "1.0.0" user nil)
+    _ (log/info "Command sent: :kixi.datastore.filestore/create-upload-link" )
     (wait-for-pred #(deref file-id-atom))
     (run! (partial c/detach-handler! comms) ehs)
     (if-not (clojure.string/blank? @file-id-atom)


### PR DESCRIPTION
It's been a bit of a storm getting this test working, because it received a torrent of events which totally upset it. There's a real concern here that Kafka consumers aren't quite doing what we think... This fix is a patch to get the gateway green again but further investigation is needed at the kixi.comms level.