### PR TITLE
put secrets bucket and aws region in env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ ADD target/witan.gateway-standalone.jar /srv/witan.gateway.jar
 ADD scripts/run.sh /etc/service/gateway/run
 ADD scripts/nginx.sh /etc/service/nginx/run
 
-ARG SECRETS_BUCKET
-ARG AWS_REGION
 ENV SECRETS_BUCKET=$SECRETS_BUCKET
 ENV AWS_REGION=$AWS_REGION
 

--- a/witan-gateway.json.template
+++ b/witan-gateway.json.template
@@ -7,6 +7,8 @@
       "parameters": [
          {"key": "env", "value": "ENVIRONMENT=@@ENVIRONMENT@@"},
          {"key": "env", "value": "JAVA_OPTS=@@JAVA_OPTS@@"},
+         {"key": "env", "value": "SECRETS_BUCKET=@@SECRETS_BUCKET@@"},
+         {"key": "env", "value": "AWS_REGION=@@AWS_REGION@@"},
          {"key": "label", "value": "cluster=@@ENVIRONMENT@@"},
          {"key": "label", "value": "application=witan-gateway"}
       ],


### PR DESCRIPTION
SECRETS_BUCKET and AWS_REGION should both be env variables put in marathon template, because both are going to be different for staging and prod (instead of being baked in docker image).