### PR TITLE
Use ZK to design a unique app name for Kixi Comms

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,4 +1,9 @@
 {:service-name "witan.gateway"
+ :zk {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]
+                      :staging-jenkins "master.mesos"
+                      :staging "master.mesos"
+                      :prod "master.mesos"}
+      :port 2181}
  :comms {:kinesis #profile {:development {:profile "dev"
                                           :app ^:ref [:service-name]
                                           :endpoint "kinesis.eu-central-1.amazonaws.com"
@@ -31,11 +36,7 @@
                                    :metric-level :NONE
                                    :streams {:event "prod-witan-event"
                                              :command "prod-witan-command"}}}}
- :events {:host #profile {:development #or [#env ZOOKEEPER "127.0.0.1"]
-                          :staging-jenkins "master.mesos"
-                          :staging "master.mesos"
-                          :prod "master.mesos"}
-          :port 2181}
+ :events ^:ref [:zk]
  :connections {}
  :webserver {:port 30015}
  :auth {:pubkey #profile {:development #or [#env SUPER_SECRET_PUBLIC_PEM_FILE

--- a/src/witan/gateway/components/comms_wrapper.clj
+++ b/src/witan/gateway/components/comms_wrapper.clj
@@ -1,0 +1,77 @@
+(ns witan.gateway.components.comms-wrapper
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre            :as log]
+            [zookeeper                  :as zk]
+            [amazonica.aws.dynamodbv2 :as ddb]
+            ;;
+            [kixi.comms :as comms]
+            [kixi.comms.components.kinesis :as kinesis]))
+
+(defn- fix-app-name
+  [{:keys [host port]}]
+  (fn [app]
+    (let [zk-conn (zk/connect (str host ":" port))
+          seq-name (zk/create-all zk-conn "/kixi/gateway/app-name-" :sequential? true)
+          consumer-name (clojure.string/replace (subs seq-name 1) #"/" "-")
+          number (second (re-find #".+-([0-9]{10})" consumer-name))]
+      (zk/close zk-conn)
+      (str app "-" number))))
+
+(defn- table-exists?
+  [endpoint table]
+  (try
+    (ddb/describe-table {:endpoint endpoint} table)
+    (catch Exception e false)))
+
+(defn- clear-tables
+  [endpoint table-names]
+  (doseq [sub-table-names (partition-all 10 table-names)]
+    (doseq [table-name sub-table-names]
+      (ddb/delete-table {:endpoint endpoint} :table-name table-name))
+    (loop [tables sub-table-names]
+      (when (not-empty tables)
+        (recur (doall (filter (partial table-exists? endpoint) tables)))))))
+
+(defn- tear-down!
+  [kinesis]
+  (log/info "Deleting dynamo tables ...")
+  (clear-tables (:dynamodb-endpoint kinesis)
+                [(kinesis/event-worker-app-name (:app kinesis) (:profile kinesis))
+                 (kinesis/command-worker-app-name (:app kinesis) (:profile kinesis))]))
+
+(defrecord CommsWrapper [config
+                         inner-comms]
+  comms/Communications
+  (send-event! [this event version payload]
+    (comms/send-event! inner-comms event version payload))
+  (send-event! [this event version payload opts]
+    (comms/send-event! inner-comms event version payload opts))
+  (send-command! [this command version user payload]
+    (comms/send-command! inner-comms command version user payload))
+  (send-command! [this command version user payload opts]
+    (comms/send-command! inner-comms command version user payload opts))
+  (attach-event-handler! [this group-id event version handler]
+    (comms/attach-event-handler! inner-comms group-id event version handler))
+  (attach-event-with-key-handler! [this group-id map-key handler]
+    (comms/attach-event-with-key-handler! inner-comms group-id map-key handler))
+  (attach-command-handler! [this group-id event version handler]
+    (comms/attach-command-handler! inner-comms group-id event version handler))
+  (detach-handler! [this handler]
+    (comms/detach-handler! inner-comms handler))
+  component/Lifecycle
+  (start [component]
+    (let [comms (kinesis/map->Kinesis config)]
+      (assoc component
+             :profile (:profile config)
+             :app (:app config)
+             :inner-comms (component/start comms))))
+  (stop [{:keys [inner-comms] :as component}]
+    (component/stop inner-comms)
+    (tear-down! inner-comms)
+    (dissoc component
+            :profile
+            :app
+            :inner-comms)))
+
+(defn new-comms-wrapper [config zk-config]
+  (map->CommsWrapper {:config (update config :app (fix-app-name zk-config))}))

--- a/src/witan/gateway/components/connection_manager.clj
+++ b/src/witan/gateway/components/connection_manager.clj
@@ -3,7 +3,6 @@
             [taoensso.timbre            :as log]
             [clj-time.core              :as t]
             [clojure.spec               :as s]
-            [kixi.comms                 :as c]
             [witan.gateway.protocols    :as p :refer [ManageConnections]]
             [zookeeper                  :as zk]))
 
@@ -39,7 +38,7 @@
                                             :at (t/now)}))
 
   component/Lifecycle
-  (start [{:keys [comms events] :as component}]
+  (start [{:keys [events] :as component}]
     (log/info "Starting Connection Manager")
     (let [c (assoc component
                    :channels  (atom #{})
@@ -48,7 +47,7 @@
       (p/register-event-receiver! events cmfn)
       (assoc c :cmfn cmfn)))
 
-  (stop [{:keys [comms events] :as component}]
+  (stop [{:keys [events] :as component}]
     (log/info "Stopping Connection Manager")
     (p/unregister-event-receiver! events (:cmfn component))
     (dissoc component

--- a/src/witan/gateway/handler.clj
+++ b/src/witan/gateway/handler.clj
@@ -149,7 +149,7 @@
 
 (defmethod handle-message
   "ping"
-  [ch {:keys [kixi.comms.ping/id]} user {:keys [comms connections]}]
+  [ch {:keys [kixi.comms.ping/id]} user {:keys [_ connections]}]
   (log/trace "Received ping!")
   (send-outbound! ch (merge {:kixi.comms.message/type "pong"
                              :kixi.comms.pong/created-at (timestamp)}


### PR DESCRIPTION
This means each instance of the Gateway will have a unique consumer,
which solves the problem of scaling the Gateway (because each Gateway
needs to receive all events and they wouldn't when they share an app
name).
We also clear up the Dynamo table it will have created so that we don't
have orphan tables hanging around
