### PR TITLE
Make query router slightly more robust

### DIFF
--- a/test/witan/gateway/integration/query_test.clj
+++ b/test/witan/gateway/integration/query_test.clj
@@ -43,6 +43,17 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(deftest broken-query
+  (let [qid (uuid)
+        resp (atom nil)]
+    (reset! received-fn #(reset! resp %))
+    (send-query qid :datastore/metadata-with-activities [:kixi.datastore.metadatastore/file-read])
+    (wait-for-pred #(deref resp))
+    (is (= (:kixi.comms.message/type @resp) "query-response"))
+    (is (= (:kixi.comms.query/id @resp) qid))
+    (is (= (get-in @resp [:kixi.comms.query/results 0 :datastore/metadata-with-activities :error])
+           "incorrect amount of arguments were supplied"))))
+
 (deftest metadata-activites-count
   (let [rcount (rand-nth (range 5 15))
         qid (uuid)


### PR DESCRIPTION
**Make query router slightly more robust**
We saw some arity exceptions in the whild which are plausible in the
case that a UI is 'out of date' with the Gateway API. We just want to
give a less menacing error in this case,.