### PR TITLE
Increasing search page size

### DIFF
--- a/src/witan/gateway/queries/search.clj
+++ b/src/witan/gateway/queries/search.clj
@@ -30,7 +30,8 @@
                                                 :kixi.datastore.metadatastore/license
                                                 :kixi.datastore.metadatastore/size-bytes
                                                 :kixi.datastore.metadatastore/sharing]
-                                       :from from})
+                                       :from from
+                                       :size 50})
                                :content-type :json
                                :accept :json
                                :throw-exceptions false


### PR DESCRIPTION
Results are being filtered by files already present in datapacks,
for large datapacks with repetative names, this is leaving no
results. This gives the impression that there is nothing found.