### PR TITLE
Removing search query elements

### DIFF
--- a/src/witan/gateway/components/query_router.clj
+++ b/src/witan/gateway/components/query_router.clj
@@ -22,9 +22,9 @@
    :datastore/metadata-with-activities qds/metadata-with-activities
    :datastore/metadata-by-id qds/metadata-by-id
 
-   :search/dashboard search/dashboard
-   :search/datapack-files search/datapack-files
-   :search/datapack-files-expand search/datapack-files
+   :search/dashboard search/execute-search
+   :search/datapack-files search/execute-search
+   :search/datapack-files-expand search/execute-search
 
    :groups/search qh/group-search})
 

--- a/src/witan/gateway/queries/search.clj
+++ b/src/witan/gateway/queries/search.clj
@@ -23,8 +23,8 @@
 
 (defn metadata-by-id
   [u d id]
-  (let [search-url (directory-url :search d)
-        response (http/get (str search-url "metadata/" id)
+  (let [search-url (directory-url :search d "metadata/" id)
+        response (http/get search-url
                            {:content-type :json
                             :accept :json
                             :throw-exceptions false


### PR DESCRIPTION
Removing all input to search queries, making it much more of a pass
through. This puts all of the control for the queries into the ui.