### PR TITLE
User group info caches

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.3.443"]
                  [org.clojure/data.codec "0.1.0"]
+                 [org.clojure/core.memoize "0.7.1"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.taoensso/timbre "4.8.0"]
                  [com.cognitect/transit-clj "0.8.290"]

--- a/src/medley.clj
+++ b/src/medley.clj
@@ -1,0 +1,15 @@
+(ns medley)
+
+(defn- editable? [coll]
+  (instance? clojure.lang.IEditableCollection coll))
+
+(defn- reduce-map [f coll]
+  (if (editable? coll)
+    (persistent! (reduce-kv (f assoc!) (transient (empty coll)) coll))
+    (reduce-kv (f assoc) (empty coll) coll)))
+
+
+(defn map-vals
+  "Maps a function over the values of an associative collection."
+  [f coll]
+  (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll))

--- a/src/witan/gateway/queries/heimdall.clj
+++ b/src/witan/gateway/queries/heimdall.clj
@@ -1,6 +1,7 @@
 (ns witan.gateway.queries.heimdall
   (:require [taoensso.timbre :as log]
             [org.httpkit.client :as http]
+            [clojure.core.memoize :refer [fifo]]
             [witan.gateway.handler :refer [transit-encode transit-decode]]
             [witan.gateway.queries.utils :refer [directory-url user-header error-response]]))
 
@@ -23,6 +24,28 @@
 (defn get-groups-info
   [u d groups & _]
   (get-elements u d "groups" (vec groups)))
+
+(defn get-user-info-
+  [u d user-id]
+  (get-elements u d "users" [user-id]))
+
+(def user-info-cache-size 100)
+
+(def get-user-info
+  (fifo get-user-info-
+        :fifo/threshold
+        user-info-cache-size))
+
+(def group-info-cache-size 100)
+
+(defn get-group-info-
+  [u d group-id]
+  (get-elements u d "groups" [group-id]))
+
+(def get-group-info
+  (fifo get-group-info-
+        :fifo/threshold
+        group-info-cache-size))
 
 (defn group-search
   [u d & _]


### PR DESCRIPTION
Introduces clojure core memozie cache wrappers for heimdall user and
group info fetching.

Currently just set to fifo cache, as it's the simplest and will most
likely meet our needs completely. Size hard coded to 100 for both.